### PR TITLE
Set image build and tagging to basilisk version 2.1.7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  BSK_VERSION: "2.1.7"
 
 jobs:
   publish:
@@ -24,6 +25,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: AVSLab/basilisk
+          ref: ${{ env.BSK_VERSION }}
           lfs: true
           path: basilisk
 
@@ -44,10 +46,12 @@ jobs:
 
       # Build, scan, and push basilisk-jupyterlabs Docker artifacts.
       - name: Extract metadata (tags, labels) for basilisk-jupyterlabs Docker image
-        id: basiliskJupyterLabs
+        id: metadata
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/lasp/basilisk-jupyterlabs
+        tags: |
+          type=raw, value=${{ env.BSK_VERSION }}
 
       - name: Build basilisk-jupyterlabs Docker image
         uses: docker/build-push-action@v3
@@ -74,5 +78,5 @@ jobs:
           file: basilisk-jupyterlabs.Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.basiliskJupyterLabs.outputs.tags }}
-          labels: ${{ steps.basiliskJupyterLabs.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,6 +3,9 @@ name: "Pull Request"
 on:
   pull_request:
 
+env:
+  BSK_VERSION: "2.1.7"
+
 jobs:
   build-linux:
     name: Build Linux
@@ -18,6 +21,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: AVSLab/basilisk
+          ref: ${{ env.BSK_VERSION }}
           lfs: true
           path: basilisk
       - name: "Apt-get Update"


### PR DESCRIPTION
* **Tickets addressed:** NA
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Updated build and publish script to build and tag image for a specific release of Basilisk. This change targets the latest Basilisk 2.1.7 

## Verification
Will wait for CI to run.

## Documentation
None needed.

## Future work
None.
