### PR TITLE
Remove scan action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,16 +82,6 @@ jobs:
           load: true
           tags: ${{ env.REGISTRY }}/lasp/basilisk-jupyterlabs:${{ github.sha }}
 
-      - name: Scan basilisk-jupyterlabs Docker image
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ env.REGISTRY }}/lasp/basilisk-jupyterlabs:${{ github.sha }}
-          format: 'table'
-          exit-code: '0'
-          ignore-unfixed: true
-          severity: 'CRITICAL'
-          timeout: 10m0s
-
       - name: Push basilisk-jupyterlabs Docker image
         uses: docker/build-push-action@v5
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,8 @@ fonttools==4.43.0
 fqdn==1.5.1
 idna==3.4
 iniconfig==2.0.0
+ipympl==0.9.3
+ipdb==0.13.13
 ipykernel==6.20.2
 ipython==8.10.0
 ipython-genutils==0.2.0


### PR DESCRIPTION
* **Tickets addressed:** NA
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR drops the trivy scan from the docker image build and publish workflow for the time being. It also adds in the `ipdb` interactive debugger for better debugging in `.py` files, and the `ipympl` package for generating interactive plots using `%matplotlib ipympl` or `%matplotlib widget`.

## Verification
Built and tested

## Documentation
NA

## Future work
NA
